### PR TITLE
align devcontainer.json and compose.yaml configurations

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -42,6 +42,7 @@ RUN <<EOF
 curl https://mise.jdx.dev/install.sh.sig | gpg --decrypt > install.sh
 sh ./install.sh
 : 'mise setup for bash'
+echo 'export PATH=$PATH:~/.local/bin' >> ~/.bashrc
 echo 'eval "$(mise activate bash)"' >> ~/.bashrc
 : 'allow the execution of git commands in a container workspace'
 git config --global safe.directory ${WORKING_DIR}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,15 +5,15 @@
 
   // Update the 'dockerComposeFile' list if you have more compose files or use different names.
   // The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
-  "dockerComposeFile": ["../compose.yml"],
+  "dockerComposeFile": ["../compose.yaml"],
 
   // The 'service' property is the name of the service for the container that VS Code should
   // use. Update this value and .devcontainer/docker-compose.yml to the real service name.
-  "service": "nippo-cli",
+  "service": "app",
 
   // The optional 'workspaceFolder' property is the path VS Code should open by default when
   // connected. This is typically a file mount in .devcontainer/docker-compose.yml
-  "workspaceFolder": "/workspaces/nippo-cli",
+  "workspaceFolder": "/workspaces/app",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {},

--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,13 @@ GO_BUILD:=-ldflags '${GO_LDFLAGS}' -trimpath
 all: build
 
 .PHONY: build
-build: nippo
+build: app
 
 .PHONY: debug
 debug: BINDIR:=/tmp
 debug: GO_BUILD:=-gcflags='all=-N -l' -ldflags '${GO_LDFLAGS_VERSION}'
-debug: nippo
+debug: app
 
-.PHONY: nippo
-nippo: nippo/nippo.go
-	go build -o $(BINDIR)/$@ $(GO_BUILD) $^
+.PHONY: app
+app: nippo/nippo.go
+	go build -o $(BINDIR)/$(<F:.go=) $(GO_BUILD) $^

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ nippo deploy
 
 ```console
 // host
-$ (echo UID=$(id -u) & echo GID=$(id -g)) > .env
+$ cp .env.sample .env
+$ (echo UID=$(id -u) & echo GID=$(id -g)) >> .env
 $ docker compose up -d
-$ docker compose exec nippo-cli bash
+$ docker compose exec app bash
 
 // container
 $ mise trust


### PR DESCRIPTION
solves: #5 

## 前提 / Prerequisites

- コンテナが起動しない

## なぜこのPRが必要になったか / Why do we need this PR

- コンテナが起動しない原因となっている設定のミスマッチを解消するため

## なにをやったか / What I did

- .devcontainer/devcontainer.json
  - ファイル名誤り修正（compose.yml -> compose.yaml）
  - service / workspaces の名前を`nippo-cli`から`app`に修正
- compose.yaml
  - サービス名を `app` に修正
- Makefile
  - ターゲット名を`nippo`から`app`に修正
  - ビルドするバイナリ名をエントリーのファイル名から作成するように修正（nippo/nippo.go -> nippo）

## 影響範囲 / Affected by the change

- なし
