### PR TITLE
add dependabot settings

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,20 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+  - package-ecosystem: 'devcontainers'
+    directory: '/'
+    schedule:
+      interval: weekly
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: weekly
+  - package-ecosystem: 'gomod'
+    directory: '/'
+    schedule:
+      interval: weekly


### PR DESCRIPTION
solves: #9 

## 前提 / Prerequisites

- dependabotが未導入

## なにをやったか / What I did

- [c18t/boilerplate-go-cli](https://github.com/c18t/boilerplate-go-cli) から [.github/dependabot.yaml](https://github.com/c18t/boilerplate-go-cli/blob/main/.github/dependabot.yaml) を取り込み
