### PR TITLE
fix(release): resolve GoReleaser configuration issues

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,4 +1,0 @@
-changelog:
-  exclude:
-    labels:
-      - tagpr

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
   release:
     needs: tagpr
     if: needs.tagpr.outputs.tagpr-tag != ''
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: write

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ builds:
       - darwin
 
 archives:
-  - formats: ['tar.gz']
+  - formats: [tar.gz]
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -38,7 +38,7 @@ archives:
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        formats: ['zip']
+        formats: [zip]
 
 changelog:
   sort: asc
@@ -47,3 +47,10 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+
+release:
+  footer: >-
+
+    ---
+
+    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).


### PR DESCRIPTION
solves: #54

## 前提 / Prerequisites

- リリースワークフローが ubuntu-slim ランナーで失敗していた
- GoReleaser の設定に改善の余地があった

## なぜこのPRが必要になったか / Why do we need this PR

リリースワークフローがビルドに失敗し、新しいバージョンのリリースができない状態でした。

## なにをやったか / What I did

- ubuntu-slim ランナーを ubuntu-latest に変更（ビルドに失敗するため）
- GoReleaser の archives.formats で引用符スタイルを修正
- 重複する .github/release.yaml を削除
- リリースフッターを追加

## 影響範囲 / Affected by the change

- リリースワークフロー (.github/workflows/release.yaml)
- GoReleaser 設定 (.goreleaser.yaml)
- GitHub Release の changelog 設定

## 懸念事項 / Concerns

特になし

## 補足 / Supplementary information

🤖 Generated with [Claude Code](https://claude.com/claude-code)