### PR TITLE
chore(ci): update go-test workflow and octocov push settings

### DIFF
--- a/badges/coverage.svg
+++ b/badges/coverage.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="133.5" height="20" role="img" aria-label="octocov::badge">
+    <title>octocov::badge</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="133.5" height="20" rx="3" fill="#fff"/>
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="83.5" height="20" fill="#24292E"/>
+        <rect x="83.5" width="50" height="20" fill="#DFB317"/>
+        <rect width="133.5" height="20" fill="url(#s)"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        
+        <image x="5" y="3" width="14" height="14" xlink:href="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiB2aWV3Qm94PSIwIDAgMTAwIDEwMCIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxuczpzZXJpZj0iaHR0cDovL3d3dy5zZXJpZi5jb20vIiBzdHlsZT0iZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjI7Ij4KICAgIDxwYXRoIGQ9Ik05NS44ODEsMzAuODk5TDY5LjEwMSw0LjExOUwzMC44OTksNC4xMTlMNC4xMTksMzAuODk5TDQuMTE5LDY5LjEwMUwzMC44OTksOTUuODgxTDY5LjEwMSw5NS44ODFMOTUuODgxLDY5LjEwMUw5NS44ODEsMzAuODk5Wk02My4xMTQsMTguNTYzTDgxLjQzNywzNi44ODZMODEuNDM3LDYzLjExNEw2My4xMTQsODEuNDM3TDM2Ljg4Niw4MS40MzdMMTguNTYzLDYzLjExNEwxOC41NjMsMzYuODg2TDM2Ljg4NiwxOC41NjNMNjMuMTE0LDE4LjU2M1oiIHN0eWxlPSJmaWxsOnJnYigxNDksMTU3LDE2NSk7Ij48L3BhdGg+Cjwvc3ZnPg=="/>
+        
+        <text aria-hidden="true" x="495" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">coverage</text>
+        <text x="495" y="140" transform="scale(.1)" fill="#fff">coverage</text>
+        <text aria-hidden="true" x="1085" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">53.8%</text>
+        <text x="1085" y="140" transform="scale(.1)" fill="#fff">53.8%</text>
+    </g>
+</svg>

--- a/badges/ratio.svg
+++ b/badges/ratio.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="168.5" height="20" role="img" aria-label="octocov::badge">
+    <title>octocov::badge</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="168.5" height="20" rx="3" fill="#fff"/>
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="124.5" height="20" fill="#24292E"/>
+        <rect x="124.5" width="44" height="20" fill="#A4A61D"/>
+        <rect width="168.5" height="20" fill="url(#s)"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        
+        <image x="5" y="3" width="14" height="14" xlink:href="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiB2aWV3Qm94PSIwIDAgMTAwIDEwMCIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxuczpzZXJpZj0iaHR0cDovL3d3dy5zZXJpZi5jb20vIiBzdHlsZT0iZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjI7Ij4KICAgIDxwYXRoIGQ9Ik05NS44ODEsMzAuODk5TDY5LjEwMSw0LjExOUwzMC44OTksNC4xMTlMNC4xMTksMzAuODk5TDQuMTE5LDY5LjEwMUwzMC44OTksOTUuODgxTDY5LjEwMSw5NS44ODFMOTUuODgxLDY5LjEwMUw5NS44ODEsMzAuODk5Wk02My4xMTQsMTguNTYzTDgxLjQzNywzNi44ODZMODEuNDM3LDYzLjExNEw2My4xMTQsODEuNDM3TDM2Ljg4Niw4MS40MzdMMTguNTYzLDYzLjExNEwxOC41NjMsMzYuODg2TDM2Ljg4NiwxOC41NjNMNjMuMTE0LDE4LjU2M1oiIHN0eWxlPSJmaWxsOnJnYigxNDksMTU3LDE2NSk7Ij48L3BhdGg+Cjwvc3ZnPg=="/>
+        
+        <text aria-hidden="true" x="700" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">code to test ratio</text>
+        <text x="700" y="140" transform="scale(.1)" fill="#fff">code to test ratio</text>
+        <text aria-hidden="true" x="1465" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">1:1.1</text>
+        <text x="1465" y="140" transform="scale(.1)" fill="#fff">1:1.1</text>
+    </g>
+</svg>

--- a/badges/time.svg
+++ b/badges/time.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="165.5" height="20" role="img" aria-label="octocov::badge">
+    <title>octocov::badge</title>
+    <linearGradient id="s" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <clipPath id="r">
+        <rect width="165.5" height="20" rx="3" fill="#fff"/>
+    </clipPath>
+    <g clip-path="url(#r)">
+        <rect width="134.5" height="20" fill="#24292E"/>
+        <rect x="134.5" width="31" height="20" fill="#97CA00"/>
+        <rect width="165.5" height="20" fill="url(#s)"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
+        
+        <image x="5" y="3" width="14" height="14" xlink:href="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiB2aWV3Qm94PSIwIDAgMTAwIDEwMCIgdmVyc2lvbj0iMS4xIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4bWw6c3BhY2U9InByZXNlcnZlIiB4bWxuczpzZXJpZj0iaHR0cDovL3d3dy5zZXJpZi5jb20vIiBzdHlsZT0iZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7c3Ryb2tlLWxpbmVqb2luOnJvdW5kO3N0cm9rZS1taXRlcmxpbWl0OjI7Ij4KICAgIDxwYXRoIGQ9Ik05NS44ODEsMzAuODk5TDY5LjEwMSw0LjExOUwzMC44OTksNC4xMTlMNC4xMTksMzAuODk5TDQuMTE5LDY5LjEwMUwzMC44OTksOTUuODgxTDY5LjEwMSw5NS44ODFMOTUuODgxLDY5LjEwMUw5NS44ODEsMzAuODk5Wk02My4xMTQsMTguNTYzTDgxLjQzNywzNi44ODZMODEuNDM3LDYzLjExNEw2My4xMTQsODEuNDM3TDM2Ljg4Niw4MS40MzdMMTguNTYzLDYzLjExNEwxOC41NjMsMzYuODg2TDM2Ljg4NiwxOC41NjNMNjMuMTE0LDE4LjU2M1oiIHN0eWxlPSJmaWxsOnJnYigxNDksMTU3LDE2NSk7Ij48L3BhdGg+Cjwvc3ZnPg=="/>
+        
+        <text aria-hidden="true" x="750" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">test execution time</text>
+        <text x="750" y="140" transform="scale(.1)" fill="#fff">test execution time</text>
+        <text aria-hidden="true" x="1500" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">1s</text>
+        <text x="1500" y="140" transform="scale(.1)" fill="#fff">1s</text>
+    </g>
+</svg>


### PR DESCRIPTION
resolves: -

## 前提 / Prerequisites

- octocov によるカバレッジバッジの更新を main ブランチでのみ動作するようにしていた

## なぜこのPRが必要になったか / Why do we need this PR

- main ブランチは保護されているため、GitHub Actions から push できない
- octocov のコミットメッセージを conventional commit 形式に統一したい

## なにをやったか / What I did

- go-test ワークフローのトリガーを `branches: main` から `branches-ignore: main` に変更
  - main 以外のブランチへの push 時に octocov によるバッヂ作成が行われるようになる
- octocov の `report` と `push` から `if: is_default_branch` 条件を削除
- octocov の push メッセージを conventional commit 形式に変更

## 影響範囲 / Affected by the change

- CI ワークフローの実行タイミング
- octocov によるコミットメッセージの形式

## 懸念事項 / Concerns

- なし

## 補足 / Supplementary information

- なし