### PR TITLE
chore(pnpm): limit network concurrency to avoid socket timeouts

### DIFF
--- a/badges/time.svg
+++ b/badges/time.svg
@@ -1,16 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="165.5" height="20" role="img" aria-label="octocov::badge">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="171.5" height="20" role="img" aria-label="octocov::badge">
     <title>octocov::badge</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
     </linearGradient>
     <clipPath id="r">
-        <rect width="165.5" height="20" rx="3" fill="#fff"/>
+        <rect width="171.5" height="20" rx="3" fill="#fff"/>
     </clipPath>
     <g clip-path="url(#r)">
         <rect width="134.5" height="20" fill="#24292E"/>
-        <rect x="134.5" width="31" height="20" fill="#97CA00"/>
-        <rect width="165.5" height="20" fill="url(#s)"/>
+        <rect x="134.5" width="37" height="20" fill="#97CA00"/>
+        <rect width="171.5" height="20" fill="url(#s)"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
         
@@ -18,7 +18,7 @@
         
         <text aria-hidden="true" x="750" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">test execution time</text>
         <text x="750" y="140" transform="scale(.1)" fill="#fff">test execution time</text>
-        <text aria-hidden="true" x="1500" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">2s</text>
-        <text x="1500" y="140" transform="scale(.1)" fill="#fff">2s</text>
+        <text aria-hidden="true" x="1530" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">42s</text>
+        <text x="1530" y="140" transform="scale(.1)" fill="#fff">42s</text>
     </g>
 </svg>

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+# pnpm v10 では auth/registry 以外の設定は .npmrc ではなくこのファイルに書く
+# cf. https://pnpm.io/settings
+
+# npm レジストリへの同時 HTTP リクエスト数の上限。
+# デフォルト (auto: 16-64) では WSL2 環境でソケットタイムアウトが多発する。
+# コールドインストール実測: auto=失敗, 16=78s, 8=31s, 3=16s (2回計測で再現)
+networkConcurrency: 3


### PR DESCRIPTION
resolves: なし（DXレビュー項目5）

## 前提 / Prerequisites

- `pnpm install` / `pnpm up` が npm レジストリへのソケットタイムアウトで頻繁に失敗していた（#103 作業中に顕在化）

## なぜこのPRが必要になったか / Why do we need this PR

pnpm v10.24+ のデフォルト `networkConcurrency` は auto（ワーカー数×3、16〜64 にクランプ、さらに maxsockets はその3倍/origin）で、WSL2 の NAT 環境では並列接続が輻輳してタイムアウトが多発するため。

## なにをやったか / What I did

- `pnpm-workspace.yaml` を新設し `networkConcurrency: 3` を設定
- pnpm v10 では auth/registry 以外の設定は .npmrc でなく pnpm-workspace.yaml が正規の置き場所（<https://pnpm.io/settings>）
- 一時ストア + `--frozen-lockfile` でコールドインストールを実測比較（各2回）:

| networkConcurrency | 結果 |
|---|---|
| auto（デフォルト） | 失敗（ERR_SOCKET_TIMEOUT） |
| 16 | 78s（内部リトライで遅延） |
| 8 | 31s / 31s |
| 3 | **15.7s / 15.6s（最速・安定）** |

## 影響範囲 / Affected by the change

- ローカル・devcontainer での pnpm install のみ（CI は npm install を行わないため影響なし）

## 懸念事項 / Concerns

- WSL2 以外の高速な環境では並列 3 が理論上ボトルネックになり得るが、依存ツリーが軽量化済み（#103）のため実害は小さい

## 補足 / Supplementary information

- 旧 pnpm-workspace.yaml（onlyBuiltDependencies: node-pty）は #103 で削除済み。本PRは設定ファイルとしての再作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)