### PR TITLE
ci(dependabot): group updates to avoid lockfile conflict chains

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,11 +14,29 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
+    # actions の更新を1つの PR にまとめる
+    groups:
+      github-actions:
+        patterns:
+          - '*'
   - package-ecosystem: npm
     directory: '/'
     schedule:
       interval: monthly
+    # 全て devDependencies のため1つの PR にまとめる
+    # （個別 PR だと pnpm-lock.yaml がマージのたびに競合し rebase の連鎖になる）
+    groups:
+      npm-dev-dependencies:
+        patterns:
+          - '*'
   - package-ecosystem: gomod
     directory: '/'
     schedule:
       interval: weekly
+    # minor/patch は1つの PR にまとめ、破壊的変更があり得る major は個別 PR のまま
+    # （個別 PR だと go.sum がマージのたびに競合し rebase の連鎖になる）
+    groups:
+      gomod-minor-patch:
+        update-types:
+          - minor
+          - patch

--- a/badges/time.svg
+++ b/badges/time.svg
@@ -1,16 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="165.5" height="20" role="img" aria-label="octocov::badge">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="171.5" height="20" role="img" aria-label="octocov::badge">
     <title>octocov::badge</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
     </linearGradient>
     <clipPath id="r">
-        <rect width="165.5" height="20" rx="3" fill="#fff"/>
+        <rect width="171.5" height="20" rx="3" fill="#fff"/>
     </clipPath>
     <g clip-path="url(#r)">
         <rect width="134.5" height="20" fill="#24292E"/>
-        <rect x="134.5" width="31" height="20" fill="#97CA00"/>
-        <rect width="165.5" height="20" fill="url(#s)"/>
+        <rect x="134.5" width="37" height="20" fill="#97CA00"/>
+        <rect width="171.5" height="20" fill="url(#s)"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
         
@@ -18,7 +18,7 @@
         
         <text aria-hidden="true" x="750" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">test execution time</text>
         <text x="750" y="140" transform="scale(.1)" fill="#fff">test execution time</text>
-        <text aria-hidden="true" x="1500" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">2s</text>
-        <text x="1500" y="140" transform="scale(.1)" fill="#fff">2s</text>
+        <text aria-hidden="true" x="1530" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">39s</text>
+        <text x="1530" y="140" transform="scale(.1)" fill="#fff">39s</text>
     </g>
 </svg>


### PR DESCRIPTION
resolves: なし（DXレビュー項目3）

## 前提 / Prerequisites

- Dependabot が依存ごとに個別 PR を作成する設定だった
- 1件マージするごとに残りの PR が pnpm-lock.yaml / go.sum で競合し、`@dependabot rebase` 待ちが連鎖する（#83〜#100 の滞留の構造的原因）

## なぜこのPRが必要になったか / Why do we need this PR

lockfile を共有する更新を1つの PR にまとめることで、競合の連鎖自体をなくすため。

## なにをやったか / What I did

- `.github/dependabot.yaml` に `groups:` を追加
  - **github-actions**: 全更新を1 PR に集約（月次）
  - **npm**: 全更新を1 PR に集約（月次。全て devDependencies のため一括で問題なし）
  - **gomod**: minor/patch を1 PR に集約（週次）。**major は従来どおり個別 PR**（破壊的変更の検証を単独で行うため）

## 影響範囲 / Affected by the change

- Dependabot の PR 数が減る（npm: 最大1本/月、gomod: minor/patch 1本/週 + major 個別）
- 既存の open PR には影響しない（次回スケジュール実行から適用）

## 懸念事項 / Concerns

- グループ PR 内の1パッケージだけ更新に問題がある場合、その1件のために PR 全体を見送るか `dependabot ignore` で除外する運用になる

## 補足 / Supplementary information

- devcontainers エコシステムは更新頻度が低く競合実績もないため従来のまま

🤖 Generated with [Claude Code](https://claude.com/claude-code)