### PR TITLE
chore(lint): use pnpm-managed markdownlint-cli2 in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,10 +16,15 @@ repos:
       - id: shellcheck
       - id: yamllint
 
-  - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.18.1
+  # markdownlint-cli2 は package.json (pnpm) 管理のバージョンを使う
+  # (remote hook だと rev と package.json の二重管理でバージョンが乖離するため)
+  - repo: local
     hooks:
       - id: markdownlint-cli2
+        name: markdownlint-cli2
+        entry: markdownlint-cli2
+        language: system
+        types: [markdown]
 
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: '3.0.0'

--- a/badges/time.svg
+++ b/badges/time.svg
@@ -1,16 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="165.5" height="20" role="img" aria-label="octocov::badge">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="171.5" height="20" role="img" aria-label="octocov::badge">
     <title>octocov::badge</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
     </linearGradient>
     <clipPath id="r">
-        <rect width="165.5" height="20" rx="3" fill="#fff"/>
+        <rect width="171.5" height="20" rx="3" fill="#fff"/>
     </clipPath>
     <g clip-path="url(#r)">
         <rect width="134.5" height="20" fill="#24292E"/>
-        <rect x="134.5" width="31" height="20" fill="#97CA00"/>
-        <rect width="165.5" height="20" fill="url(#s)"/>
+        <rect x="134.5" width="37" height="20" fill="#97CA00"/>
+        <rect width="171.5" height="20" fill="url(#s)"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
         
@@ -18,7 +18,7 @@
         
         <text aria-hidden="true" x="750" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">test execution time</text>
         <text x="750" y="140" transform="scale(.1)" fill="#fff">test execution time</text>
-        <text aria-hidden="true" x="1500" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">2s</text>
-        <text x="1500" y="140" transform="scale(.1)" fill="#fff">2s</text>
+        <text aria-hidden="true" x="1530" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">37s</text>
+        <text x="1530" y="140" transform="scale(.1)" fill="#fff">37s</text>
     </g>
 </svg>

--- a/openspec/changes/archive/2025-12-13-refactor-file-structure/specs/file-paths/spec.md
+++ b/openspec/changes/archive/2025-12-13-refactor-file-structure/specs/file-paths/spec.md
@@ -139,7 +139,8 @@ troubleshooting. The TUI implementation SHALL follow the patterns defined in
 
 - **WHEN** user runs `nippo doctor` command
 - **THEN** the system SHALL check configuration validity
-- **AND** the system SHALL check project settings (drive folder, site URL, URL, branch)
+- **AND** the system SHALL check project settings (drive folder, site URL,
+  URL, branch)
 - **AND** the system SHALL check all resolved directory paths for existence
 - **AND** the system SHALL check required files (credentials.json, token.json,
   templates/, assets/)

--- a/openspec/specs/file-paths/spec.md
+++ b/openspec/specs/file-paths/spec.md
@@ -2,7 +2,8 @@
 
 ## Purpose
 
-TBD - created by archiving change refactor-file-structure. Update Purpose after archive.
+TBD - created by archiving change refactor-file-structure. Update Purpose
+after archive.
 
 ## Requirements
 
@@ -143,7 +144,8 @@ troubleshooting. The TUI implementation SHALL follow the patterns defined in
 
 - **WHEN** user runs `nippo doctor` command
 - **THEN** the system SHALL check configuration validity
-- **AND** the system SHALL check project settings (drive folder, site URL, URL, branch)
+- **AND** the system SHALL check project settings (drive folder, site URL,
+  URL, branch)
 - **AND** the system SHALL check all resolved directory paths for existence
 - **AND** the system SHALL check required files (credentials.json, token.json,
   templates/, assets/)


### PR DESCRIPTION
resolves: なし（DXレビュー項目6）

## 前提 / Prerequisites

- markdownlint-cli2 が pre-commit の remote hook rev（v0.18.1）と package.json（^0.20.0）で二重管理されていた

## なぜこのPRが必要になったか / Why do we need this PR

バージョンが乖離すると、手元の `pnpm exec markdownlint-cli2` と pre-commit で結果が食い違い、「ローカルで通ったのにコミットで落ちる」（またはその逆）が起きるため。実際に v0.20.0 では検出されて v0.18.1 では素通りする行が3行存在した。

## なにをやったか / What I did

- pre-commit の markdownlint-cli2 を remote hook から `repo: local`（`language: system`）に変更し、package.json 管理のバージョンに一本化
- v0.20.0 で新たに検出される MD013（80字超）3行を折り返しで修正
  - `openspec/specs/file-paths/spec.md`（2行）
  - `openspec/changes/archive/2025-12-13-refactor-file-structure/specs/file-paths/spec.md`（1行）

## 影響範囲 / Affected by the change

- pre-commit 実行に node_modules が必要になる（`mise run setup` 済み環境では従来どおり）
- 以後 markdownlint のバージョン更新は Dependabot の npm 更新（#109 でグループ化済み）に統合される

## 懸念事項 / Concerns

- なし（リンティングルール自体は変更していない）

## 補足 / Supplementary information

- アーカイブ済み openspec ドキュメントの修正は行の折り返しのみで内容変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)