### PR TITLE
docs(openspec): stop pinning go version in project.md

### DIFF
--- a/badges/time.svg
+++ b/badges/time.svg
@@ -1,16 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="165.5" height="20" role="img" aria-label="octocov::badge">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="171.5" height="20" role="img" aria-label="octocov::badge">
     <title>octocov::badge</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
     </linearGradient>
     <clipPath id="r">
-        <rect width="165.5" height="20" rx="3" fill="#fff"/>
+        <rect width="171.5" height="20" rx="3" fill="#fff"/>
     </clipPath>
     <g clip-path="url(#r)">
         <rect width="134.5" height="20" fill="#24292E"/>
-        <rect x="134.5" width="31" height="20" fill="#97CA00"/>
-        <rect width="165.5" height="20" fill="url(#s)"/>
+        <rect x="134.5" width="37" height="20" fill="#97CA00"/>
+        <rect width="171.5" height="20" fill="url(#s)"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
         
@@ -18,7 +18,7 @@
         
         <text aria-hidden="true" x="750" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">test execution time</text>
         <text x="750" y="140" transform="scale(.1)" fill="#fff">test execution time</text>
-        <text aria-hidden="true" x="1500" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">2s</text>
-        <text x="1500" y="140" transform="scale(.1)" fill="#fff">2s</text>
+        <text aria-hidden="true" x="1530" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">41s</text>
+        <text x="1530" y="140" transform="scale(.1)" fill="#fff">41s</text>
     </g>
 </svg>

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -8,7 +8,7 @@ sites from markdown content stored in Google Drive, and deploy them to Vercel.
 
 ## Tech Stack
 
-- **Language**: Go 1.25.3
+- **Language**: Go (version: see `go.mod`)
 - **CLI Framework**: [spf13/cobra](https://github.com/spf13/cobra)
 - **Configuration**: [spf13/viper](https://github.com/spf13/viper)
 - **Dependency Injection**: [samber/do/v2](https://github.com/samber/do) v2.0.0
@@ -142,7 +142,8 @@ Refer to `@openspec/AGENTS.md` for detailed workflow.
 
 ## Important Constraints
 
-- **Go version**: Must use Go 1.25.3 or compatible
+- **Go version**: Follow the `go` directive in `go.mod` (toolchain is managed
+  via `.mise.toml`)
 - **DI pattern**: Always use `GetInjector().Clone()` for command-specific
   injectors to maintain scope isolation
 - **Error handling**: Never use `do.MustInvoke` - always use `do.Invoke` with


### PR DESCRIPTION
resolves: なし（DXレビュー項目7）

## 前提 / Prerequisites

- `openspec/project.md` の Tech Stack と Important Constraints に「Go 1.25.3」が直書きされていた
- 実際のツールチェーンは go.mod / .mise.toml で 1.25.5（#108 マージ後は 1.25.12）であり、既に乖離していた

## なぜこのPRが必要になったか / Why do we need this PR

バージョン番号をドキュメントに直書きすると、ツールチェーン更新のたびに更新漏れで drift が発生するため。参照先を単一の情報源（go.mod）に変える。

## なにをやったか / What I did

- Tech Stack: `Go 1.25.3` → `Go (version: see go.mod)`
- Important Constraints: `Must use Go 1.25.3 or compatible` → go.mod の go directive に従う旨へ変更（ツールチェーン管理は .mise.toml）

## 影響範囲 / Affected by the change

- ドキュメントのみ

## 懸念事項 / Concerns

- なし

## 補足 / Supplementary information

- #108（Go 1.25.12 への更新）とどちらを先にマージしても矛盾は生じない

🤖 Generated with [Claude Code](https://claude.com/claude-code)