### PR TITLE
docs(github): add pull request template for release integration PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,33 @@
+<!-- markdownlint-disable-next-line MD041 -->
+リリース対象: #XX, #XX, #XX
+
+## 含まれる PR / Included PRs
+
+<!-- マージ順に列挙する -->
+
+- #XX タイトル
+- #XX タイトル
+
+## 競合解消 / Conflict resolutions
+
+<!-- 統合時に解消した競合があれば「どのファイルを・どちら側で・なぜ」を書く -->
+
+- なし
+
+## マージ方法 / How to merge
+
+> [!IMPORTANT]
+> 必ず **Create a merge commit** でマージすること（squash / rebase 不可）。
+> 各 PR ブランチの head コミットが main に到達することで、含まれる PR が
+> 自動的に Merged 扱いになる。squash すると SHA が変わるため自動クローズ
+> されず、手動で閉じることになる。
+
+## マージ後の確認 / Post-merge checks
+
+<!-- 例: main の CI 実行、リリースワークフローの発火、バッジ更新など -->
+
+-
+
+## 補足 / Supplementary information
+
+<!-- 統合状態での検証結果 (pre-commit / build / test) をここに書く -->

--- a/badges/time.svg
+++ b/badges/time.svg
@@ -1,16 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="165.5" height="20" role="img" aria-label="octocov::badge">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="171.5" height="20" role="img" aria-label="octocov::badge">
     <title>octocov::badge</title>
     <linearGradient id="s" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
         <stop offset="1" stop-opacity=".1"/>
     </linearGradient>
     <clipPath id="r">
-        <rect width="165.5" height="20" rx="3" fill="#fff"/>
+        <rect width="171.5" height="20" rx="3" fill="#fff"/>
     </clipPath>
     <g clip-path="url(#r)">
         <rect width="134.5" height="20" fill="#24292E"/>
-        <rect x="134.5" width="31" height="20" fill="#97CA00"/>
-        <rect width="165.5" height="20" fill="url(#s)"/>
+        <rect x="134.5" width="37" height="20" fill="#97CA00"/>
+        <rect width="171.5" height="20" fill="url(#s)"/>
     </g>
     <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
         
@@ -18,7 +18,7 @@
         
         <text aria-hidden="true" x="750" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">test execution time</text>
         <text x="750" y="140" transform="scale(.1)" fill="#fff">test execution time</text>
-        <text aria-hidden="true" x="1500" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">2s</text>
-        <text x="1500" y="140" transform="scale(.1)" fill="#fff">2s</text>
+        <text aria-hidden="true" x="1530" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)">38s</text>
+        <text x="1530" y="140" transform="scale(.1)" fill="#fff">38s</text>
     </g>
 </svg>


### PR DESCRIPTION
resolves: なし

## 前提 / Prerequisites

- #112 のような「複数 PR を束ねるリリース統合 PR」を作る運用が始まった
- 統合 PR には通常テンプレートと異なる定型項目（含まれる PR 一覧、merge commit 必須の注意、統合検証結果）がある

## なぜこのPRが必要になったか / Why do we need this PR

リリース統合 PR で毎回「squash すると含まれる PR が自動クローズされない」注意を思い出すのは事故のもとなので、テンプレートに焼き込むため。

## なにをやったか / What I did

- `.github/PULL_REQUEST_TEMPLATE/release.md` を追加（デフォルトの `pull_request_template.md` はそのまま）
- 項目: 含まれる PR 一覧 / 競合解消 / マージ方法（merge commit 必須の IMPORTANT アラート）/ マージ後の確認 / 補足
- markdownlint クリーン（MD041 のみ inline disable、README と同じ流儀）

## 影響範囲 / Affected by the change

- なし（追加テンプレートは明示指定時のみ使われる: `gh pr create --template release.md` または URL に `?template=release.md`）

## 懸念事項 / Concerns

- PR テンプレートには issue テンプレートのような選択 UI が無いため、存在を忘れると使われない（README 等への追記はしていない）

## 補足 / Supplementary information

- boilerplate-go-cli にも同じテンプレートを別 PR で移植予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)